### PR TITLE
Merge "Incorrect Credentials" to have the same status code and message.

### DIFF
--- a/api_doc.md
+++ b/api_doc.md
@@ -77,7 +77,7 @@ A session token is not required to perform this action.
 |-------|-----------------------------------------------------------------|-------------|
 | `201` | A JSON object containing a single field, called `session_token` | The user was logged in successfully. |
 | `400` | A JSON error object                                             | Username or passsword were not included in the request. |
-| `401` | A JSON error object                                             | Wrong username or password. |
+| `401` | A JSON error object                                             | Incorrect username or password. |
 
 ### Logging Out (i.e. Deleting a Session)
 

--- a/api_doc.md
+++ b/api_doc.md
@@ -77,8 +77,7 @@ A session token is not required to perform this action.
 |-------|-----------------------------------------------------------------|-------------|
 | `201` | A JSON object containing a single field, called `session_token` | The user was logged in successfully. |
 | `400` | A JSON error object                                             | Username or passsword were not included in the request. |
-| `401` | A JSON error object                                             | Wrong password. |
-| `404` | A JSON error object                                             | A user with the provided username doesn't exist. |
+| `401` | A JSON error object                                             | Wrong username or password. |
 
 ### Logging Out (i.e. Deleting a Session)
 

--- a/auth.go
+++ b/auth.go
@@ -58,12 +58,12 @@ func PostSessions(w http.ResponseWriter, req *http.Request) {
 	var u User
 	err = DB.QueryRow("select * from users where username = ?", username).Scan(&u.Id, &u.Username, &u.DisplayName, &u.PasswordHash, &u.Role)
 	if err == sql.ErrNoRows {
-		WriteJSONError(w, http.StatusUnauthorized, "Wrong username or password.")
+		WriteJSONError(w, http.StatusUnauthorized, "Incorrect username or password.")
 		return
 	}
 	err = bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(password))
 	if err != nil {
-		WriteJSONError(w, http.StatusUnauthorized, "Wrong username or password.")
+		WriteJSONError(w, http.StatusUnauthorized, "Incorrect username or password.")
 		return
 	}
 	unixTimestamp := time.Now().Unix()

--- a/auth.go
+++ b/auth.go
@@ -58,12 +58,12 @@ func PostSessions(w http.ResponseWriter, req *http.Request) {
 	var u User
 	err = DB.QueryRow("select * from users where username = ?", username).Scan(&u.Id, &u.Username, &u.DisplayName, &u.PasswordHash, &u.Role)
 	if err == sql.ErrNoRows {
-		WriteJSONError(w, http.StatusNotFound, "That user doesn't exist. Check your username.")
+		WriteJSONError(w, http.StatusUnauthorized, "Wrong username or password.")
 		return
 	}
 	err = bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(password))
 	if err != nil {
-		WriteJSONError(w, http.StatusUnauthorized, "Wrong password")
+		WriteJSONError(w, http.StatusUnauthorized, "Wrong username or password.")
 		return
 	}
 	unixTimestamp := time.Now().Unix()


### PR DESCRIPTION
It is allowing for easier brute-force attacks to have "incorrect username" and "incorrect password" error's have different status codes and response messages.
